### PR TITLE
Add Pine64 patches from apritzel/u-boot

### DIFF
--- a/arch/arm/cpu/armv7/lowlevel_init.S
+++ b/arch/arm/cpu/armv7/lowlevel_init.S
@@ -19,7 +19,11 @@ ENTRY(lowlevel_init)
 	/*
 	 * Setup a temporary stack. Global data is not available yet.
 	 */
+#if defined(CONFIG_SPL_BUILD) && defined(CONFIG_SPL_STACK)
+	ldr	sp, =CONFIG_SPL_STACK
+#else
 	ldr	sp, =CONFIG_SYS_INIT_SP_ADDR
+#endif
 	bic	sp, sp, #7 /* 8-byte alignment for ABI compliance */
 #ifdef CONFIG_SPL_DM
 	mov	r9, #0

--- a/arch/arm/dts/sun50i-a64-pine64-common.dtsi
+++ b/arch/arm/dts/sun50i-a64-pine64-common.dtsi
@@ -46,6 +46,7 @@
 
 	aliases {
 		serial0 = &uart0;
+		ethernet0 = &emac;
 	};
 
 	soc {

--- a/arch/arm/mach-sunxi/clock_sun6i.c
+++ b/arch/arm/mach-sunxi/clock_sun6i.c
@@ -21,6 +21,8 @@ void clock_init_safe(void)
 {
 	struct sunxi_ccm_reg * const ccm =
 		(struct sunxi_ccm_reg *)SUNXI_CCM_BASE;
+
+#ifdef CONFIG_MACH_SUN6I
 	struct sunxi_prcm_reg * const prcm =
 		(struct sunxi_prcm_reg *)SUNXI_PRCM_BASE;
 
@@ -31,6 +33,7 @@ void clock_init_safe(void)
 		PRCM_PLL_CTRL_LDO_DIGITAL_EN | PRCM_PLL_CTRL_LDO_ANALOG_EN |
 		PRCM_PLL_CTRL_EXT_OSC_EN | PRCM_PLL_CTRL_LDO_OUT_L(1140));
 	clrbits_le32(&prcm->pll_ctrl1, PRCM_PLL_CTRL_LDO_KEY_MASK);
+#endif
 
 	clock_set_pll1(408000000);
 
@@ -41,7 +44,9 @@ void clock_init_safe(void)
 	writel(AHB1_ABP1_DIV_DEFAULT, &ccm->ahb1_apb1_div);
 
 	writel(MBUS_CLK_DEFAULT, &ccm->mbus0_clk_cfg);
+#ifdef CONFIG_MACH_SUN6I
 	writel(MBUS_CLK_DEFAULT, &ccm->mbus1_clk_cfg);
+#endif
 }
 #endif
 

--- a/include/configs/sunxi-common.h
+++ b/include/configs/sunxi-common.h
@@ -219,15 +219,17 @@
 #define CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR	80	/* 40KiB */
 #define CONFIG_SPL_PAD_TO		32768		/* decimal for 'dd' */
 
-#if defined(CONFIG_MACH_SUN9I) || defined(CONFIG_MACH_SUN50I)
-/* FIXME: 40 KiB instead of 32 KiB ? */
+#if defined(CONFIG_MACH_SUN9I)
+/* end of 40 KiB in SRAM A1 */
+#define LOW_LEVEL_SRAM_STACK		0x0001a000
+#elif defined(CONFIG_MACH_SUN50I)
+/* end of 32 KiB SRAM A1 for now, as SRAM C is unreliable */
 #define LOW_LEVEL_SRAM_STACK		0x00018000
-#define CONFIG_SPL_STACK		LOW_LEVEL_SRAM_STACK
 #else
 /* end of 32 KiB in sram */
 #define LOW_LEVEL_SRAM_STACK		0x00008000 /* End of sram */
-#define CONFIG_SPL_STACK		LOW_LEVEL_SRAM_STACK
 #endif
+#define CONFIG_SPL_STACK		LOW_LEVEL_SRAM_STACK
 
 /* I2C */
 #if defined CONFIG_AXP152_POWER || defined CONFIG_AXP209_POWER || \


### PR DESCRIPTION
I'm currently working on getting the pine64 upstream images up-to-date and the newest ATF requires a much newer u-boot. The Pine64 is supported by v2016.09.01 in u-boot, but these patches are nice to have. With this in place, u-boot-pine64(plus) can be a _link to u-boot in OBS instead of a hacked together package.
I'm not sure whether tumbleweed-staging is the right place, maybe a new branch is a good idea until those patches have been merged.
