### PR TITLE
rock64-rk3328 memory fixes

### DIFF
--- a/drivers/ram/rockchip/sdram_rk3328.c
+++ b/drivers/ram/rockchip/sdram_rk3328.c
@@ -394,7 +394,7 @@ static void phy_cfg(struct dram_info *dram,
 	copy_to_reg(PHY_REG(phy_base, 0x70),
 		    &sdram_params->skew.cs0_dm0_skew[0], 44 * 4);
 	copy_to_reg(PHY_REG(phy_base, 0xc0),
-		    &sdram_params->skew.cs0_dm1_skew[0], 44 * 4);
+		    &sdram_params->skew.cs1_dm0_skew[0], 44 * 4);
 }
 
 static int update_refresh_reg(struct dram_info *dram)

--- a/drivers/ram/rockchip/sdram_rk3328.c
+++ b/drivers/ram/rockchip/sdram_rk3328.c
@@ -311,12 +311,12 @@ static void phy_dll_bypass_set(struct dram_info *dram, u32 freq)
 	setbits_le32(PHY_REG(phy_base, 0x56), 1 << 4);
 	clrbits_le32(PHY_REG(phy_base, 0x57), 1 << 3);
 
-	if (freq <= (400 * MHz))
+	if (freq <= 400)
 		/* DLL bypass */
 		setbits_le32(PHY_REG(phy_base, 0xa4), 0x1f);
 	else
 		clrbits_le32(PHY_REG(phy_base, 0xa4), 0x1f);
-	if (freq <= (680 * MHz))
+	if (freq <= 680)
 		tmp = 2;
 	else
 		tmp = 1;


### PR DESCRIPTION
Hi,

This two patches improve rk3328 TPL stability and they are queued for inclusion for 2020.01. It would be great to have them applied for 2019.10 to finally have full rock64 support.