### PR TITLE
arm64: dts: meson: odroidc2: readd PHY reset properties

### DIFF
--- a/arch/arm/dts/meson-gxbb-odroidc2-u-boot.dtsi
+++ b/arch/arm/dts/meson-gxbb-odroidc2-u-boot.dtsi
@@ -29,6 +29,12 @@
 	};
 };
 
+&ethmac {
+	snps,reset-gpio = <&gpio GPIOZ_14 0>;
+	snps,reset-delays-us = <0 10000 1000000>;
+	snps,reset-active-low;
+};
+
 &usb0 {
 	status = "disabled";
 };


### PR DESCRIPTION
The sync of the device tree and dt-bindings from Linux v5.6-rc2
11a48a5a18c6 ("Linux 5.6-rc2") causes Ethernet to break on some
ODROID-C2. The PHY seems to need proper reset timing to be functional
in U-Boot and Linux afterwards. Readd the old PHY reset bindings for
dwmac until we support the new bindings in the PHY node.

Fixes: dd5f2351e99a ("arm64: dts: meson: sync dt and bindings from v5.6-rc2")
Signed-off-by: Stefan Agner <stefan@agner.ch>
Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
(cherry picked from commit a246e21351778a93805b3f52302a420f4b268601)

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1187095
