### PR TITLE
Disable timer check in file loading

### DIFF
--- a/lib/efi_loader/efi_disk.c
+++ b/lib/efi_loader/efi_disk.c
@@ -15,6 +15,7 @@
 #include <log.h>
 #include <part.h>
 #include <malloc.h>
+#include <watchdog.h>
 
 struct efi_system_partition efi_system_partition;
 
@@ -103,8 +104,7 @@ static efi_status_t efi_disk_rw_blocks(struct efi_block_io *this,
 	else
 		n = blk_dwrite(desc, lba, blocks, buffer);
 
-	/* We don't do interrupts, so check for timers cooperatively */
-	efi_timer_check();
+	WATCHDOG_RESET();
 
 	EFI_PRINT("n=%lx blocks=%x\n", n, blocks);
 


### PR DESCRIPTION
The u-boot efi console service registers a timer to poll the keyboard
input in every 50ns. In the efi block io service, this timer is
evaluated on each block read, and since the timer interval is much less
than the time needed to reading out a block (32kB) from the disk, the
keyboard polling is therefore in the wake of each block read.

Unfortunately USB keyboard spends too much time in polling. In my test
usb_kbd_poll_for_event costs 40ms in usb_kbd_testc() to test if a
character is in the queue. In combination with the number of blocks to
be read from the disk, the extra amound of time delayed could be around
30 seconds to load linux and initrd.

For that matters, the timer check is disabled in file loading to speed
it up. The consequence would be losing the keystroke during the time
file is loading, but that is acceptable IMHO.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
