### PR TITLE
Fix for "RPi4 fails to boot with U-Boot 2023.10"

### DIFF
--- a/boot/bootdev-uclass.c
+++ b/boot/bootdev-uclass.c
@@ -460,10 +460,11 @@ int bootdev_find_by_label(const char *label, struct udevice **devp,
 			 * if no sequence number was provided, we must scan all
 			 * bootdevs for this media uclass
 			 */
-			if (IS_ENABLED(CONFIG_BOOTSTD_FULL) && seq == -1)
+			if (seq == -1)
 				method_flags |= BOOTFLOW_METHF_SINGLE_UCLASS;
 			if (method_flagsp)
 				*method_flagsp = method_flags;
+			log_debug("method flags %x\n", method_flags);
 			return 0;
 		}
 		log_debug("- no device in %s\n", media->name);

--- a/boot/bootdev-uclass.c
+++ b/boot/bootdev-uclass.c
@@ -460,11 +460,10 @@ int bootdev_find_by_label(const char *label, struct udevice **devp,
 			 * if no sequence number was provided, we must scan all
 			 * bootdevs for this media uclass
 			 */
-			if (seq == -1)
+			if (IS_ENABLED(CONFIG_BOOTSTD_FULL) && seq == -1)
 				method_flags |= BOOTFLOW_METHF_SINGLE_UCLASS;
 			if (method_flagsp)
 				*method_flagsp = method_flags;
-			log_debug("method flags %x\n", method_flags);
 			return 0;
 		}
 		log_debug("- no device in %s\n", media->name);

--- a/boot/bootflow.c
+++ b/boot/bootflow.c
@@ -280,8 +280,26 @@ static int iter_incr(struct bootflow_iter *iter)
 		} else {
 			log_debug("labels %p\n", iter->labels);
 			if (iter->labels) {
-				ret = bootdev_next_label(iter, &dev,
-							 &method_flags);
+				/*
+				 * when the label is "mmc" we want to scan all
+				 * mmc bootdevs, not just the first. See
+				 * bootdev_find_by_label() where this flag is
+				 * set up
+				 */
+				if (iter->method_flags &
+				    BOOTFLOW_METHF_SINGLE_UCLASS) {
+					scan_next_in_uclass(&dev);
+					log_debug("looking for next device %s: %s\n",
+						  iter->dev->name,
+						  dev ? dev->name : "<none>");
+				} else {
+					dev = NULL;
+				}
+				if (!dev) {
+					log_debug("looking at next label\n");
+					ret = bootdev_next_label(iter, &dev,
+								 &method_flags);
+				}
 			} else {
 				ret = bootdev_next_prio(iter, &dev);
 				method_flags = 0;

--- a/boot/bootflow.c
+++ b/boot/bootflow.c
@@ -156,6 +156,27 @@ static void bootflow_iter_set_dev(struct bootflow_iter *iter,
 }
 
 /**
+ * scan_next_in_uclass() - Scan for the next bootdev in the same media uclass
+ *
+ * Move through the following bootdevs until we find another in this media
+ * uclass, or run out
+ *
+ * @devp: On entry, the device to check, on exit the new device, or NULL if
+ * there is none
+ */
+static void scan_next_in_uclass(struct udevice **devp)
+{
+	struct udevice *dev = *devp;
+	enum uclass_id cur_id = device_get_uclass_id(dev->parent);
+
+	do {
+		uclass_find_next_device(&dev);
+	} while (dev && cur_id != device_get_uclass_id(dev->parent));
+
+	*devp = dev;
+}
+
+/**
  * iter_incr() - Move to the next item (method, part, bootdev)
  *
  * Return: 0 if OK, BF_NO_MORE_DEVICES if there are no more bootdevs
@@ -230,8 +251,7 @@ static int iter_incr(struct bootflow_iter *iter)
 						 &method_flags);
 		} else if (IS_ENABLED(CONFIG_BOOTSTD_FULL) &&
 			   (iter->flags & BOOTFLOWIF_SINGLE_UCLASS)) {
-			/* Move to the next bootdev in this uclass */
-			uclass_find_next_device(&dev);
+			scan_next_in_uclass(&dev);
 			if (!dev) {
 				log_debug("finished uclass %s\n",
 					  dev_get_uclass_name(dev));

--- a/boot/bootflow.c
+++ b/boot/bootflow.c
@@ -260,25 +260,8 @@ static int iter_incr(struct bootflow_iter *iter)
 		} else {
 			log_debug("labels %p\n", iter->labels);
 			if (iter->labels) {
-				/*
-				 * when the label is "mmc" we want to scan all
-				 * mmc bootdevs, not just the first. See
-				 * bootdev_find_by_label() where this flag is
-				 * set up
-				 */
-				if (iter->method_flags & BOOTFLOW_METHF_SINGLE_UCLASS) {
-					uclass_next_device(&dev);
-					log_debug("looking for next device %s: %s\n",
-						  iter->dev->name,
-						  dev ? dev->name : "<none>");
-				} else {
-					dev = NULL;
-				}
-				if (!dev) {
-					log_debug("looking at next label\n");
-					ret = bootdev_next_label(iter, &dev,
-								 &method_flags);
-				}
+				ret = bootdev_next_label(iter, &dev,
+							 &method_flags);
 			} else {
 				ret = bootdev_next_prio(iter, &dev);
 				method_flags = 0;

--- a/test/boot/bootdev.c
+++ b/test/boot/bootdev.c
@@ -221,16 +221,6 @@ static int bootdev_test_order(struct unit_test_state *uts)
 	ut_asserteq_str("mmc2.bootdev", iter.dev_used[1]->name);
 	bootflow_iter_uninit(&iter);
 
-	/* Make sure it scans a bootdevs in each target */
-	ut_assertok(env_set("boot_targets", "mmc spi"));
-	ut_asserteq(0, bootflow_scan_first(NULL, NULL, &iter, 0, &bflow));
-	ut_asserteq(-ENODEV, bootflow_scan_next(&iter, &bflow));
-	ut_asserteq(3, iter.num_devs);
-	ut_asserteq_str("mmc2.bootdev", iter.dev_used[0]->name);
-	ut_asserteq_str("mmc1.bootdev", iter.dev_used[1]->name);
-	ut_asserteq_str("mmc0.bootdev", iter.dev_used[2]->name);
-	bootflow_iter_uninit(&iter);
-
 	return 0;
 }
 BOOTSTD_TEST(bootdev_test_order, UT_TESTF_DM | UT_TESTF_SCAN_FDT);

--- a/test/boot/bootdev.c
+++ b/test/boot/bootdev.c
@@ -232,6 +232,19 @@ static int bootdev_test_order(struct unit_test_state *uts)
 			iter.dev_used[2]->name);
 	bootflow_iter_uninit(&iter);
 
+	/* Try a single uclass */
+	ut_assertok(env_set("boot_targets", NULL));
+	ut_assertok(bootflow_scan_first(NULL, "mmc", &iter, 0, &bflow));
+	ut_asserteq(2, iter.num_devs);
+
+	/* Now scan pass mmc1 and make sure that only mmc0 shows up */
+	ut_asserteq(-ENODEV, bootflow_scan_next(&iter, &bflow));
+	ut_asserteq(3, iter.num_devs);
+	ut_asserteq_str("mmc2.bootdev", iter.dev_used[0]->name);
+	ut_asserteq_str("mmc1.bootdev", iter.dev_used[1]->name);
+	ut_asserteq_str("mmc0.bootdev", iter.dev_used[2]->name);
+	bootflow_iter_uninit(&iter);
+
 	return 0;
 }
 BOOTSTD_TEST(bootdev_test_order, UT_TESTF_DM | UT_TESTF_SCAN_FDT);


### PR DESCRIPTION
Second attempt to fix boo#1216036. Tested on RPi4. Boot from USB  and uSD fine.
For details see: https://lore.kernel.org/u-boot/20231023070216.394709-1-sjg@chromium.org/#t

