### PR TITLE
riscv: dts: jh7110: Update qspi node with upstream

### DIFF
--- a/arch/riscv/dts/jh7110-starfive-visionfive-2-u-boot.dtsi
+++ b/arch/riscv/dts/jh7110-starfive-visionfive-2-u-boot.dtsi
@@ -40,7 +40,7 @@
 &qspi {
 	bootph-pre-ram;
 
-	nor-flash@0 {
+	nor_flash@0 {
 		bootph-pre-ram;
 	};
 };

--- a/arch/riscv/dts/jh7110-starfive-visionfive-2.dtsi
+++ b/arch/riscv/dts/jh7110-starfive-visionfive-2.dtsi
@@ -305,17 +305,38 @@
 };
 
 &qspi {
-	spi-max-frequency = <250000000>;
+	#address-cells = <1>;
+	#size-cells = <0>;
 	status = "okay";
 
-	nor-flash@0 {
+	nor_flash: nor_flash@0 {
 		compatible = "jedec,spi-nor";
-		reg=<0>;
-		spi-max-frequency = <100000000>;
+		reg = <0>;
+		cdns,read-delay = <5>;
+		spi-max-frequency = <12000000>;
 		cdns,tshsl-ns = <1>;
 		cdns,tsd2d-ns = <1>;
 		cdns,tchsh-ns = <1>;
 		cdns,tslch-ns = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			spl@0 {
+				reg = <0x0 0x80000>;
+			};
+			uboot-env@f0000 {
+				reg = <0xf0000 0x10000>;
+			};
+			uboot@100000 {
+				reg = <0x100000 0x400000>;
+			};
+			reserved-data@600000 {
+				reg = <0x600000 0xa00000>;
+			};
+		};
 	};
 };
 

--- a/arch/riscv/dts/jh7110.dtsi
+++ b/arch/riscv/dts/jh7110.dtsi
@@ -480,19 +480,22 @@
 		};
 
 		qspi: spi@13010000 {
-			compatible = "cdns,qspi-nor";
-			reg = <0x0 0x13010000 0x0 0x10000
-				0x0 0x21000000 0x0 0x400000>;
-			clocks = <&syscrg JH7110_SYSCLK_QSPI_REF>;
-			clock-names = "clk_ref";
+			compatible = "starfive,jh7110-qspi", "cdns,qspi-nor";
+			reg = <0x0 0x13010000 0x0 0x10000>,
+			      <0x0 0x21000000 0x0 0x400000>;
+			interrupts = <25>;
+			clocks = <&syscrg JH7110_SYSCLK_QSPI_REF>,
+				 <&syscrg JH7110_SYSCLK_QSPI_AHB>,
+				 <&syscrg JH7110_SYSCLK_QSPI_APB>;
+			clock-names = "ref", "ahb", "apb";
 			resets = <&syscrg JH7110_SYSRST_QSPI_APB>,
 				 <&syscrg JH7110_SYSRST_QSPI_AHB>,
 				 <&syscrg JH7110_SYSRST_QSPI_REF>;
-			reset-names = "rst_apb", "rst_ahb", "rst_ref";
+			reset-names = "qspi", "qspi-ocp", "rstc_ref";
 			cdns,fifo-depth = <256>;
 			cdns,fifo-width = <4>;
-			#address-cells = <1>;
-			#size-cells = <0>;
+			cdns,trigger-address = <0x0>;
+			status = "disabled";
 		};
 
 		syscrg: clock-controller@13020000 {


### PR DESCRIPTION
Upstream node uses a specific SoC compatible to make the kernel driver work. Copy over the upstream node to fullfill that need.
